### PR TITLE
Fix for the ReDOS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "log-devnull": "1.0.0",
     "q": "1.0.1",
-    "request": "2.72.0"
+    "request": "2.74.0"
   },
   "main": "./src/index.js",
   "scripts": {


### PR DESCRIPTION
rerun is currently affected by the high-severity [ReDOS vulnerability](https://snyk.io/vuln/npm:tough-cookie:20160722). 

Vulnerable module: `tough-cookie`
Introduced through: `request`

This PR fixes the ReDOS vulnerability by upgrading `request` to version 2.74.0

Check out the [Snyk test report](https://snyk.io/test/github/bigpandaio/rerun) to review other vulnerabilities that affect this repo. 

[Watch the repo](https://snyk.io/add) to 
- get alerts if newly disclosed vulnerabilities affect this repo in the future. 
- generate pull requests with the fixes you want, or let us do the work: when a newly disclosed vulnerability affects you, we'll submit a fix to you right away. 

Stay secure, 
The Snyk team
